### PR TITLE
feat: add stealth, memoryNamespace, continueOnFailure and sendMessage

### DIFF
--- a/nodes/Mobilerun/properties/TaskApi.properties.ts
+++ b/nodes/Mobilerun/properties/TaskApi.properties.ts
@@ -31,6 +31,13 @@ const taskProperties: INodeProperties[] = [{
 	default: {},
 	options: [
 		{
+			displayName: 'Continue on Failure',
+			name: 'continueOnFailure',
+			type: 'boolean',
+			default: false,
+			description: 'Whether the agent should continue executing if an individual action fails',
+		},
+		{
 			displayName: 'App Names or IDs',
 			name: 'apps',
 			type: 'multiOptions',
@@ -107,6 +114,14 @@ const taskProperties: INodeProperties[] = [{
 			description: 'List of files to be used in the task',
 		},
 		{
+			displayName: 'Memory Namespace',
+			name: 'memoryNamespace',
+			type: 'string',
+			default: '',
+			description: 'Memory namespace for cross-task personalization. Tasks sharing a namespace share memories.',
+			placeholder: 'e.g. alibaba',
+		},
+		{
 			displayName: 'Max Steps',
 			name: 'maxSteps',
 			type: 'number',
@@ -123,6 +138,13 @@ const taskProperties: INodeProperties[] = [{
 			default: '{\n  "type": "object",\n  "properties": {\n    "response": {\n      "type": "string",\n      "description": "The response text"\n    }\n  },\n  "required": ["response"],\n  "additionalProperties": false\n}',
 			description: 'JSON Schema that defines the structure of the AI response',
 
+		},
+		{
+			displayName: 'Stealth',
+			name: 'stealth',
+			type: 'boolean',
+			default: false,
+			description: 'Whether to enable stealth mode (human-like tap randomization, curved swipes, natural typing)',
 		},
 		{
 			displayName: 'Reasoning',
@@ -308,6 +330,21 @@ export const TaskResources = (): INodeProperties[] => {
 			displayOptions: { show: { resource: ['manageTask'] } },
 			options: [
 				{
+					name: 'Send Message',
+					value: 'sendMessage',
+					description: 'Send a message to a running agent task',
+					action: 'Send message to task',
+					routing: {
+						request: {
+							method: 'POST',
+							url: '={{ "tasks/" + $parameter.taskId + "/message" }}',
+							body: {
+								message: '={{ $parameter.message }}',
+							},
+						},
+					},
+				},
+				{
 					name: 'Stop Task',
 					value: 'stopTask',
 					description: 'Stops a task',
@@ -332,14 +369,17 @@ export const TaskResources = (): INodeProperties[] => {
 								task: '={{ $parameter.task }}',
 								llmModel: '={{ $parameter.llmModel }}',
 								apps: '={{ $parameter.options?.apps?.length ? $parameter.options.apps : undefined }}',
+								continueOnFailure: '={{ $parameter.options?.continueOnFailure !== undefined && $parameter.options.continueOnFailure !== null ? $parameter.options.continueOnFailure : undefined }}',
 								credentials: '={{ $parameter.options?.credentials?.credentialValues?.length ? $parameter.options.credentials.credentialValues : undefined }}',
 								deviceId: '={{ $parameter.deviceId }}',
 								displayId: '={{ $parameter.options?.displayId !== undefined && $parameter.options.displayId !== null ? $parameter.options.displayId : undefined }}',
 								executionTimeout: '={{ $parameter.options?.executionTimeout !== undefined && $parameter.options.executionTimeout !== null ? $parameter.options.executionTimeout : undefined }}',
 								files: '={{ $parameter.options?.files?.length ? $parameter.options.files : undefined }}',
 								maxSteps: '={{ $parameter.options?.maxSteps !== undefined && $parameter.options.maxSteps !== null ? $parameter.options.maxSteps : undefined }}',
+								memoryNamespace: '={{ $parameter.options?.memoryNamespace || undefined }}',
 								outputSchema: '={{ $parameter.options?.outputSchema ? JSON.parse($parameter.options.outputSchema) : undefined }}',
 								reasoning: '={{ $parameter.options?.reasoning !== undefined && $parameter.options.reasoning !== null ? $parameter.options.reasoning : undefined }}',
+								stealth: '={{ $parameter.options?.stealth !== undefined && $parameter.options.stealth !== null ? $parameter.options.stealth : undefined }}',
 								temperature: '={{ $parameter.options?.temperature !== undefined && $parameter.options.temperature !== null ? $parameter.options.temperature : undefined }}',
 								vision: '={{ $parameter.options?.vision !== undefined && $parameter.options.vision !== null ? $parameter.options.vision : undefined }}',
 								vpnCountry: '={{ $parameter.options?.vpnCountry || undefined }}',
@@ -361,14 +401,17 @@ export const TaskResources = (): INodeProperties[] => {
 								task: '={{ $parameter.task }}',
 								llmModel: '={{ $parameter.llmModel }}',
 								apps: '={{ $parameter.options?.apps?.length ? $parameter.options.apps : undefined }}',
+								continueOnFailure: '={{ $parameter.options?.continueOnFailure !== undefined && $parameter.options.continueOnFailure !== null ? $parameter.options.continueOnFailure : undefined }}',
 								credentials: '={{ $parameter.options?.credentials?.credentialValues?.length ? $parameter.options.credentials.credentialValues : undefined }}',
 								deviceId: '={{ $parameter.deviceId }}',
 								displayId: '={{ $parameter.options?.displayId !== undefined && $parameter.options.displayId !== null ? $parameter.options.displayId : undefined }}',
 								executionTimeout: '={{ $parameter.options?.executionTimeout !== undefined && $parameter.options.executionTimeout !== null ? $parameter.options.executionTimeout : undefined }}',
 								files: '={{ $parameter.options?.files?.length ? $parameter.options.files : undefined }}',
 								maxSteps: '={{ $parameter.options?.maxSteps !== undefined && $parameter.options.maxSteps !== null ? $parameter.options.maxSteps : undefined }}',
+								memoryNamespace: '={{ $parameter.options?.memoryNamespace || undefined }}',
 								outputSchema: '={{ $parameter.options?.outputSchema ? JSON.parse($parameter.options.outputSchema) : undefined }}',
 								reasoning: '={{ $parameter.options?.reasoning !== undefined && $parameter.options.reasoning !== null ? $parameter.options.reasoning : undefined }}',
+								stealth: '={{ $parameter.options?.stealth !== undefined && $parameter.options.stealth !== null ? $parameter.options.stealth : undefined }}',
 								temperature: '={{ $parameter.options?.temperature !== undefined && $parameter.options.temperature !== null ? $parameter.options.temperature : undefined }}',
 								vision: '={{ $parameter.options?.vision !== undefined && $parameter.options.vision !== null ? $parameter.options.vision : undefined }}',
 								vpnCountry: '={{ $parameter.options?.vpnCountry || undefined }}',
@@ -396,7 +439,7 @@ export const TaskResources = (): INodeProperties[] => {
 			placeholder: 'Enter Task ID',
 			displayOptions: {
 				show: {
-					operation: ['getTask', 'getTaskStatus', 'getTaskScreenshot', 'getTaskScreenshots', 'getTaskTrajectory', 'getTaskUIState', 'getTaskUIStates', 'stopTask'],
+					operation: ['getTask', 'getTaskStatus', 'getTaskScreenshot', 'getTaskScreenshots', 'getTaskTrajectory', 'getTaskUIState', 'getTaskUIStates', 'sendMessage', 'stopTask'],
 				},
 			},
 		},
@@ -412,6 +455,24 @@ export const TaskResources = (): INodeProperties[] => {
 			displayOptions: {
 				show: {
 					operation: ['getTaskScreenshot', 'getTaskUIState'],
+				},
+			},
+		},
+
+		{
+			displayName: 'Message',
+			name: 'message',
+			type: 'string',
+			typeOptions: {
+				rows: 3,
+			},
+			default: '',
+			required: true,
+			description: 'Message to send to the running agent',
+			placeholder: 'Enter message',
+			displayOptions: {
+				show: {
+					operation: ['sendMessage'],
 				},
 			},
 		},

--- a/nodes/Mobilerun/properties/TaskApi.properties.ts
+++ b/nodes/Mobilerun/properties/TaskApi.properties.ts
@@ -31,13 +31,6 @@ const taskProperties: INodeProperties[] = [{
 	default: {},
 	options: [
 		{
-			displayName: 'Continue on Failure',
-			name: 'continueOnFailure',
-			type: 'boolean',
-			default: false,
-			description: 'Whether the agent should continue executing if an individual action fails',
-		},
-		{
 			displayName: 'App Names or IDs',
 			name: 'apps',
 			type: 'multiOptions',
@@ -50,6 +43,13 @@ const taskProperties: INodeProperties[] = [{
 			placeholder: 'Choose App',
 			description: 'Apps configuration. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 			hint: 'For manuall app selection use n8n expressions'
+		},
+		{
+			displayName: 'Continue on Failure',
+			name: 'continueOnFailure',
+			type: 'boolean',
+			default: false,
+			description: 'Whether the agent should continue executing if an individual action fails',
 		},
 		{
 			displayName: 'Credentials',
@@ -114,19 +114,19 @@ const taskProperties: INodeProperties[] = [{
 			description: 'List of files to be used in the task',
 		},
 		{
+			displayName: 'Max Steps',
+			name: 'maxSteps',
+			type: 'number',
+			default: 100,
+			description: 'Maximum number of steps for task execution',
+		},
+		{
 			displayName: 'Memory Namespace',
 			name: 'memoryNamespace',
 			type: 'string',
 			default: '',
 			description: 'Memory namespace for cross-task personalization. Tasks sharing a namespace share memories.',
 			placeholder: 'e.g. alibaba',
-		},
-		{
-			displayName: 'Max Steps',
-			name: 'maxSteps',
-			type: 'number',
-			default: 100,
-			description: 'Maximum number of steps for task execution',
 		},
 		{
 			displayName: 'Output Schema',
@@ -140,18 +140,18 @@ const taskProperties: INodeProperties[] = [{
 
 		},
 		{
-			displayName: 'Stealth',
-			name: 'stealth',
-			type: 'boolean',
-			default: false,
-			description: 'Whether to enable stealth mode (human-like tap randomization, curved swipes, natural typing)',
-		},
-		{
 			displayName: 'Reasoning',
 			name: 'reasoning',
 			type: 'boolean',
 			default: true,
 			description: 'Whether to enable reasoning mode',
+		},
+		{
+			displayName: 'Stealth',
+			name: 'stealth',
+			type: 'boolean',
+			default: false,
+			description: 'Whether to enable stealth mode (human-like tap randomization, curved swipes, natural typing)',
 		},
 		{
 			displayName: 'Temperature',


### PR DESCRIPTION
## Summary
- Added `stealth`, `memoryNamespace`, and `continueOnFailure` options to Run Task and Run Task and Wait operations
- Added Send Message operation under Manage Task with taskId and message fields
- All four features are already public in the REST API and both SDKs — this wires them into the n8n node UI

## Test plan
- [x] TypeScript compiles with zero errors
- [x] Verified in local n8n instance: all three new options appear in Add Option dropdown
- [x] Verified in local n8n instance: Send Message operation appears in Manage Task
- [x] End-to-end test: Run Task with stealth=true, memoryNamespace="test-workflow", continueOnFailure=true — API accepted all fields, task completed successfully

Closes DRO-2075